### PR TITLE
Fix: empty info vacancy

### DIFF
--- a/internal/shared/core/model.go
+++ b/internal/shared/core/model.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 type Vacancy struct {
@@ -11,6 +12,19 @@ type Vacancy struct {
 	ShortDescription string   `json:"short_description,omitempty"`
 	RelevantTags     []string `json:"relevant_tags,omitempty"`
 	ApplyURL         string   `json:"apply_url,omitempty"`
+}
+
+func (r Vacancy) Validate() error {
+	if r.JobTitle == "" {
+		return fmt.Errorf("job title is required")
+	}
+	if r.CompanyName == "" {
+		return fmt.Errorf("company name is required")
+	}
+	if r.ApplyURL == "" {
+		return fmt.Errorf("apply url is required")
+	}
+	return nil
 }
 
 type VacancyRecord struct {

--- a/internal/vacancy-worker/driven/resolver/vacancy.go
+++ b/internal/vacancy-worker/driven/resolver/vacancy.go
@@ -66,6 +66,11 @@ func (r *VacancyResolver) Resolve(ctx context.Context, url string) (*core.Vacanc
 	}
 
 parserFound:
+	err = vac.Validate()
+	if err != nil {
+		return nil, core.NewBadRequestError(err.Error())
+	}
+
 	// if the company location is not found (which indicated by "Global Remote")
 	// locate the company's headquarters
 	if strings.Contains(strings.ToLower(vac.CompanyLocation), "remote") {

--- a/internal/vacancy-worker/driven/storage/notion/model.go
+++ b/internal/vacancy-worker/driven/storage/notion/model.go
@@ -88,7 +88,7 @@ func NewInsertRecordPaylod(databaseID string, now time.Time, v core.Vacancy) Ins
 	}
 	p.Properties.ShortDescription.RichText = descBlocks
 
-	var selects []BlockSelect
+	selects := []BlockSelect{}
 	for _, tag := range v.RelevantTags {
 		var selectItem BlockSelect
 		selectItem.Name = tag

--- a/internal/vacancy-worker/driven/storage/notion/notion_test.go
+++ b/internal/vacancy-worker/driven/storage/notion/notion_test.go
@@ -74,3 +74,29 @@ Donec eget auctor nunc. Phasellus ullamcorper odio eu odio ultrices maximus. Ves
 
 	require.NotEmpty(t, rec.ID)
 }
+
+func TestSaveNoRelevantTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	s, err := storage.NewNotionStorage(storage.NotionStorageConfig{
+		DatabaseID:  env.GetString(testutil.EnvKeyNotionDatabaseID),
+		NotionToken: env.GetString(testutil.EnvKeyNotionToken),
+		HttpClient:  resty.New(),
+	})
+	require.NoError(t, err)
+
+	vacancyLongDesc := core.Vacancy{
+		JobTitle:         "Testing Vacancy With No Relevant Tags",
+		CompanyName:      "Testing Company",
+		CompanyLocation:  "Testing Location",
+		RelevantTags:     []string{},
+		ApplyURL:         "https://example.com",
+		ShortDescription: "Lorem.",
+	}
+
+	rec, err := s.Save(context.Background(), vacancyLongDesc)
+	require.NoError(t, err)
+	require.NotEmpty(t, rec.ID)
+}


### PR DESCRIPTION
In recent incident #20, I noticed we failed to extract information from the linkedin submission url including the relevant tags. however in current implementation, relevant tags blocks cannot be empty and we dont validate it property.

### Summary

* Initialization of the multi selects blocks notion, handle empty relevant tags.
* Added a new test `TestSaveNoRelevantTags` in `internal/vacancy-worker/driven/storage/notion/notion_test.go` to verify that a `Vacancy` with no relevant tags can be saved successfully.
* Added a `Validate` method to the `Vacancy` struct in `internal/shared/core/model.go` to ensure that `JobTitle`, `CompanyName`, and `ApplyURL` are not empty.
* Call the new `Validate` method in `VacancyResolver` and handle validation errors by returning as `BadRequestError`.
