### PR TITLE
Fix: Processing on Reject

### DIFF
--- a/internal/server/core/service.go
+++ b/internal/server/core/service.go
@@ -142,10 +142,5 @@ func (s *service) HandleReject(ctx context.Context, approvalReq ApprovalRequest)
 		}
 	}
 
-	err = s.Queue.Put(ctx, req)
-	if err != nil {
-		return fmt.Errorf("failed to put request in queue: %w", err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Summary
- Removed the operation that puts the request in the queue from the `HandleReject` method.
- Add service test for `HandleApprove` and `HandleReject` methods in service