### PR TITLE
Fix: Handle Empty Tags, Logging and Save Bulk Approval

### DIFF
--- a/internal/crawler-worker/driven/crawler/model.go
+++ b/internal/crawler-worker/driven/crawler/model.go
@@ -1,15 +1,21 @@
 package crawler
 
 import (
-	"strings"
+	"net/url"
 
 	"github.com/forPelevin/gomoji"
 	"github.com/ghazlabs/idn-remote-entry/internal/shared/core"
 )
 
 func isEligibleToSave(vacancy core.Vacancy) bool {
-	// Check if the vacancy has a valid ApplyURL
-	return !strings.Contains(vacancy.ApplyURL, "/cdn-cgi/l/email-protection")
+	// Parse the URL to validate it
+	u, err := url.Parse(vacancy.ApplyURL)
+	if err != nil {
+		return false
+	}
+
+	// Check if URL has https scheme
+	return u.Scheme == "https"
 }
 
 func removeUnwantedText(text string) string {

--- a/internal/notification-worker/driver/worker/worker.go
+++ b/internal/notification-worker/driver/worker/worker.go
@@ -53,13 +53,13 @@ func (w *Worker) Run() error {
 		err = w.Config.Service.Handle(ctx, n)
 		if err != nil {
 			// output error and sleep for 1 second
-			log.Printf("failed to handle notification (attempt %d) %s: %s, sleeping for 1 second...\n", n.Retries+1, n, err)
+			log.Printf("failed to handle notification (attempt %d) %s: %s, sleeping for 1 second...\n", n.Retries+1, n.ToJSON(), err)
 			time.Sleep(1 * time.Second)
 
 			// increment retry count
 			n.Retries++
 			if n.Retries >= 3 {
-				log.Printf("discarding notification after %d retries: %s\n", n.Retries, n)
+				log.Printf("discarding notification after %d retries: %s\n", n.Retries, n.ToJSON())
 				return rabbitmq.NackDiscard
 			}
 

--- a/internal/notification-worker/driver/worker/worker.go
+++ b/internal/notification-worker/driver/worker/worker.go
@@ -71,7 +71,7 @@ func (w *Worker) Run() error {
 		}
 
 		defer func() {
-			log.Printf("handled vacancy %s in %s\n", d.Body, time.Since(startTime))
+			log.Printf("handled notification %s in %s\n", d.Body, time.Since(startTime))
 		}()
 
 		return rabbitmq.Ack

--- a/internal/server/driven/storage/mysql/mysql.go
+++ b/internal/server/driven/storage/mysql/mysql.go
@@ -89,9 +89,13 @@ func (s *MySQLStorage) SaveBulkApprovalRequest(ctx context.Context, req shcore.S
 	defer stmt.Close()
 
 	// Save each message ID with the corresponding request data
-	for _, messageID := range messageIDs {
-		data := req.ToJSON()
-		_, err := stmt.ExecContext(ctx, messageID, core.ApprovalStatePending, data)
+	for idx, messageID := range messageIDs {
+		data := shcore.SubmitRequest{
+			SubmissionType:  req.SubmissionType,
+			SubmissionEmail: req.SubmissionEmail,
+			Vacancy:         req.BulkVacancies[idx],
+		}
+		_, err := stmt.ExecContext(ctx, messageID, core.ApprovalStatePending, data.ToJSON())
 		if err != nil {
 			tx.Rollback()
 			return fmt.Errorf("failed to save bulk approval request: %w", err)

--- a/internal/server/driven/storage/mysql/mysql.go
+++ b/internal/server/driven/storage/mysql/mysql.go
@@ -74,6 +74,11 @@ func (s *MySQLStorage) SaveApprovalRequest(ctx context.Context, messageID string
 }
 
 func (s *MySQLStorage) SaveBulkApprovalRequest(ctx context.Context, req shcore.SubmitRequest, messageIDs []string) error {
+	// Validate the request
+	if len(req.BulkVacancies) != len(messageIDs) {
+		return fmt.Errorf("number of vacancies must match number of message IDs")
+	}
+
 	tx, err := s.DB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)

--- a/internal/server/driver/request.go
+++ b/internal/server/driver/request.go
@@ -1,0 +1,20 @@
+package driver
+
+import (
+	"strings"
+
+	shcore "github.com/ghazlabs/idn-remote-entry/internal/shared/core"
+)
+
+func prepareSubmitVacancyRequest(req shcore.SubmitRequest) shcore.SubmitRequest {
+	relevantTags := []string{}
+	for _, tag := range req.RelevantTags {
+		tag = strings.TrimSpace(tag)
+		if tag != "" {
+			relevantTags = append(relevantTags, tag)
+		}
+	}
+	req.RelevantTags = relevantTags
+
+	return req
+}

--- a/internal/server/driver/rest.go
+++ b/internal/server/driver/rest.go
@@ -69,6 +69,7 @@ func (a *API) serveSubmitVacancy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// handle the request
+	req = prepareSubmitVacancyRequest(req)
 	err = a.Service.HandleRequest(r.Context(), req)
 	if err != nil {
 		render.Render(w, r, NewErrorResp(err))

--- a/internal/server/driver/rest_test.go
+++ b/internal/server/driver/rest_test.go
@@ -1,0 +1,490 @@
+package driver_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ghazlabs/idn-remote-entry/internal/server/core"
+	"github.com/ghazlabs/idn-remote-entry/internal/server/driver"
+	shcore "github.com/ghazlabs/idn-remote-entry/internal/shared/core"
+)
+
+func TestAPIServeSubmitVacancy(t *testing.T) {
+	tests := []struct {
+		name              string
+		apiKey            string
+		requestBody       interface{}
+		serviceResponse   error
+		expectedStatus    int
+		expectedErrorCode string
+		validateParams    func(t *testing.T, req *shcore.SubmitRequest)
+	}{
+		{
+			name:   "success with manual submission",
+			apiKey: "test-api-key",
+			requestBody: shcore.SubmitRequest{
+				SubmissionType:  shcore.SubmitTypeManual,
+				SubmissionEmail: "test@example.com",
+				Vacancy: shcore.Vacancy{
+					JobTitle:         "Software Engineer",
+					CompanyName:      "Test Company",
+					CompanyLocation:  "Test Location",
+					ShortDescription: "Test Description",
+					RelevantTags:     []string{"tag1", "tag2"},
+					ApplyURL:         "https://example.com/apply",
+				},
+			},
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *shcore.SubmitRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, shcore.SubmitTypeManual, req.SubmissionType)
+				assert.Equal(t, "test@example.com", req.SubmissionEmail)
+				assert.Equal(t, "Software Engineer", req.Vacancy.JobTitle)
+				assert.Equal(t, "Test Company", req.Vacancy.CompanyName)
+				assert.Equal(t, "Test Location", req.Vacancy.CompanyLocation)
+				assert.Equal(t, "Test Description", req.Vacancy.ShortDescription)
+				assert.Equal(t, []string{"tag1", "tag2"}, req.Vacancy.RelevantTags)
+				assert.Equal(t, "https://example.com/apply", req.Vacancy.ApplyURL)
+			},
+		},
+		{
+			name:   "success with manual submission - with invalid tags",
+			apiKey: "test-api-key",
+			requestBody: shcore.SubmitRequest{
+				SubmissionType:  shcore.SubmitTypeManual,
+				SubmissionEmail: "test@example.com",
+				Vacancy: shcore.Vacancy{
+					JobTitle:         "Software Engineer",
+					CompanyName:      "Test Company",
+					CompanyLocation:  "Test Location",
+					ShortDescription: "Test Description",
+					RelevantTags:     []string{"tag1", "tag2", "", " "},
+					ApplyURL:         "https://example.com/apply",
+				},
+			},
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *shcore.SubmitRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, shcore.SubmitTypeManual, req.SubmissionType)
+				assert.Equal(t, "test@example.com", req.SubmissionEmail)
+				assert.Equal(t, "Software Engineer", req.Vacancy.JobTitle)
+				assert.Equal(t, "Test Company", req.Vacancy.CompanyName)
+				assert.Equal(t, "Test Location", req.Vacancy.CompanyLocation)
+				assert.Equal(t, "Test Description", req.Vacancy.ShortDescription)
+				assert.Equal(t, []string{"tag1", "tag2"}, req.Vacancy.RelevantTags)
+				assert.Equal(t, "https://example.com/apply", req.Vacancy.ApplyURL)
+			},
+		},
+		{
+			name:   "success with URL submission",
+			apiKey: "test-api-key",
+			requestBody: shcore.SubmitRequest{
+				SubmissionType:  shcore.SubmitTypeURL,
+				SubmissionEmail: "recruiter@company.com",
+				Vacancy: shcore.Vacancy{
+					ApplyURL: "https://jobs.company.com/123",
+				},
+			},
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *shcore.SubmitRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, shcore.SubmitTypeURL, req.SubmissionType)
+				assert.Equal(t, "recruiter@company.com", req.SubmissionEmail)
+				assert.Equal(t, "https://jobs.company.com/123", req.Vacancy.ApplyURL)
+			},
+		},
+		{
+			name:   "success with bulk submission",
+			apiKey: "test-api-key",
+			requestBody: shcore.SubmitRequest{
+				SubmissionType:  shcore.SubmitTypeBulk,
+				SubmissionEmail: "crawler@system.com",
+				BulkVacancies: []shcore.Vacancy{
+					{
+						JobTitle:    "Frontend Developer",
+						CompanyName: "Company A",
+						ApplyURL:    "https://example.com/jobs/1",
+					},
+					{
+						JobTitle:    "Backend Engineer",
+						CompanyName: "Company B",
+						ApplyURL:    "https://example.com/jobs/2",
+					},
+				},
+			},
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *shcore.SubmitRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, shcore.SubmitTypeBulk, req.SubmissionType)
+				assert.Equal(t, "crawler@system.com", req.SubmissionEmail)
+				assert.Len(t, req.BulkVacancies, 2)
+				assert.Equal(t, "Frontend Developer", req.BulkVacancies[0].JobTitle)
+				assert.Equal(t, "Company A", req.BulkVacancies[0].CompanyName)
+				assert.Equal(t, "https://example.com/jobs/1", req.BulkVacancies[0].ApplyURL)
+				assert.Equal(t, "Backend Engineer", req.BulkVacancies[1].JobTitle)
+			},
+		},
+		{
+			name:              "invalid api key",
+			apiKey:            "invalid-api-key",
+			requestBody:       shcore.SubmitRequest{},
+			serviceResponse:   nil,
+			expectedStatus:    http.StatusUnauthorized,
+			expectedErrorCode: "ERR_INVALID_API_KEY",
+			validateParams:    nil, // No validation needed as service won't be called
+		},
+		{
+			name:              "invalid request body",
+			apiKey:            "test-api-key",
+			requestBody:       "invalid json",
+			serviceResponse:   nil,
+			expectedStatus:    http.StatusBadRequest,
+			expectedErrorCode: "ERR_BAD_REQUEST",
+			validateParams:    nil, // No validation needed as service won't be called
+		},
+		{
+			name:   "service returns error",
+			apiKey: "test-api-key",
+			requestBody: shcore.SubmitRequest{
+				SubmissionType: shcore.SubmitTypeManual,
+				Vacancy:        shcore.Vacancy{ApplyURL: "https://example.com/apply"},
+			},
+			serviceResponse:   shcore.NewBadRequestError("validation failed"),
+			expectedStatus:    http.StatusBadRequest,
+			expectedErrorCode: "ERR_BAD_REQUEST",
+			validateParams: func(t *testing.T, req *shcore.SubmitRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, shcore.SubmitTypeManual, req.SubmissionType)
+				assert.Equal(t, "https://example.com/apply", req.Vacancy.ApplyURL)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create stub service with desired response
+			service := newStubService()
+			service.handleRequestFunc = func(ctx context.Context, req shcore.SubmitRequest) error {
+				return tt.serviceResponse
+			}
+
+			api, err := driver.NewAPI(driver.APIConfig{
+				Service:      service,
+				ClientApiKey: "test-api-key",
+			})
+			require.NoError(t, err)
+
+			// Create request
+			var body bytes.Buffer
+			if s, ok := tt.requestBody.(string); ok {
+				body.WriteString(s)
+			} else {
+				err := json.NewEncoder(&body).Encode(tt.requestBody)
+				require.NoError(t, err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/vacancies", &body)
+			req.Header.Set("X-Api-Key", tt.apiKey)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			// Call the handler
+			handler := api.GetHandler()
+			handler.ServeHTTP(w, req)
+
+			// Check the status code
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			// Parse the response
+			var respBody driver.RespBody
+			err = json.NewDecoder(resp.Body).Decode(&respBody)
+			require.NoError(t, err)
+
+			if tt.expectedErrorCode != "" {
+				assert.Equal(t, tt.expectedErrorCode, respBody.Err)
+				assert.False(t, respBody.OK)
+			} else {
+				assert.True(t, respBody.OK)
+			}
+
+			// Validate the parameters passed to the service
+			if tt.validateParams != nil && service.lastSubmitRequest != nil {
+				tt.validateParams(t, service.lastSubmitRequest)
+			}
+		})
+	}
+}
+
+func TestAPIServeApproveVacancy(t *testing.T) {
+	tests := []struct {
+		name              string
+		token             string
+		messageID         string
+		serviceResponse   error
+		expectedStatus    int
+		expectedErrorCode string
+		validateParams    func(t *testing.T, req *core.ApprovalRequest)
+	}{
+		{
+			name:            "success",
+			token:           "valid-token",
+			messageID:       "message-123",
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *core.ApprovalRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, "valid-token", req.TokenRequest)
+				assert.Equal(t, "message-123", req.MessageID)
+			},
+		},
+		{
+			name:              "missing token",
+			token:             "",
+			messageID:         "message-123",
+			serviceResponse:   nil,
+			expectedStatus:    http.StatusBadRequest,
+			expectedErrorCode: "ERR_BAD_REQUEST",
+			validateParams:    nil, // No validation needed as service won't be called
+		},
+		{
+			name:              "service returns error",
+			token:             "invalid-token",
+			messageID:         "message-123",
+			serviceResponse:   createBadRequestError("invalid token"),
+			expectedStatus:    http.StatusBadRequest,
+			expectedErrorCode: "ERR_BAD_REQUEST",
+			validateParams: func(t *testing.T, req *core.ApprovalRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, "invalid-token", req.TokenRequest)
+				assert.Equal(t, "message-123", req.MessageID)
+			},
+		},
+		{
+			name:            "token only, no message ID",
+			token:           "token-only",
+			messageID:       "",
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *core.ApprovalRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, "token-only", req.TokenRequest)
+				assert.Equal(t, "", req.MessageID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create stub service with desired response
+			service := newStubService()
+			service.handleApproveFunc = func(ctx context.Context, req core.ApprovalRequest) error {
+				return tt.serviceResponse
+			}
+
+			api, err := driver.NewAPI(driver.APIConfig{
+				Service:      service,
+				ClientApiKey: "test-api-key",
+			})
+			require.NoError(t, err)
+
+			// Create request
+			req := httptest.NewRequest(http.MethodGet, "/vacancies/approve?data="+tt.token+"&message_id="+tt.messageID, nil)
+			w := httptest.NewRecorder()
+
+			// Call the handler
+			handler := api.GetHandler()
+			handler.ServeHTTP(w, req)
+
+			// Check the status code
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			// Parse the response
+			var respBody driver.RespBody
+			err = json.NewDecoder(resp.Body).Decode(&respBody)
+			require.NoError(t, err)
+
+			if tt.expectedErrorCode != "" {
+				assert.Equal(t, tt.expectedErrorCode, respBody.Err)
+				assert.False(t, respBody.OK)
+			} else {
+				assert.True(t, respBody.OK)
+			}
+
+			// Validate the parameters passed to the service
+			if tt.validateParams != nil && service.lastApprovalRequest != nil {
+				tt.validateParams(t, service.lastApprovalRequest)
+			}
+		})
+	}
+}
+
+func TestAPIServeRejectVacancy(t *testing.T) {
+	tests := []struct {
+		name              string
+		token             string
+		messageID         string
+		serviceResponse   error
+		expectedStatus    int
+		expectedErrorCode string
+		validateParams    func(t *testing.T, req *core.ApprovalRequest)
+	}{
+		{
+			name:            "success",
+			token:           "valid-token",
+			messageID:       "message-123",
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *core.ApprovalRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, "valid-token", req.TokenRequest)
+				assert.Equal(t, "message-123", req.MessageID)
+			},
+		},
+		{
+			name:              "missing token",
+			token:             "",
+			messageID:         "message-123",
+			serviceResponse:   nil,
+			expectedStatus:    http.StatusBadRequest,
+			expectedErrorCode: "ERR_BAD_REQUEST",
+			validateParams:    nil, // No validation needed as service won't be called
+		},
+		{
+			name:              "service returns error",
+			token:             "invalid-token",
+			messageID:         "message-123",
+			serviceResponse:   createBadRequestError("invalid token"),
+			expectedStatus:    http.StatusBadRequest,
+			expectedErrorCode: "ERR_BAD_REQUEST",
+			validateParams: func(t *testing.T, req *core.ApprovalRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, "invalid-token", req.TokenRequest)
+				assert.Equal(t, "message-123", req.MessageID)
+			},
+		},
+		{
+			name:            "token only, no message ID",
+			token:           "token-only",
+			messageID:       "",
+			serviceResponse: nil,
+			expectedStatus:  http.StatusOK,
+			validateParams: func(t *testing.T, req *core.ApprovalRequest) {
+				require.NotNil(t, req)
+				assert.Equal(t, "token-only", req.TokenRequest)
+				assert.Equal(t, "", req.MessageID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create stub service with desired response
+			service := newStubService()
+			service.handleRejectFunc = func(ctx context.Context, req core.ApprovalRequest) error {
+				return tt.serviceResponse
+			}
+
+			api, err := driver.NewAPI(driver.APIConfig{
+				Service:      service,
+				ClientApiKey: "test-api-key",
+			})
+			require.NoError(t, err)
+
+			// Create request
+			req := httptest.NewRequest(http.MethodGet, "/vacancies/reject?data="+tt.token+"&message_id="+tt.messageID, nil)
+			w := httptest.NewRecorder()
+
+			// Call the handler
+			handler := api.GetHandler()
+			handler.ServeHTTP(w, req)
+
+			// Check the status code
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			// Parse the response
+			var respBody driver.RespBody
+			err = json.NewDecoder(resp.Body).Decode(&respBody)
+			require.NoError(t, err)
+
+			if tt.expectedErrorCode != "" {
+				assert.Equal(t, tt.expectedErrorCode, respBody.Err)
+				assert.False(t, respBody.OK)
+			} else {
+				assert.True(t, respBody.OK)
+			}
+
+			// Validate the parameters passed to the service
+			if tt.validateParams != nil && service.lastRejectRequest != nil {
+				tt.validateParams(t, service.lastRejectRequest)
+			}
+		})
+	}
+}
+
+// stubService is a simple implementation of core.Service for testing
+type stubService struct {
+	handleRequestFunc func(ctx context.Context, req shcore.SubmitRequest) error
+	handleApproveFunc func(ctx context.Context, req core.ApprovalRequest) error
+	handleRejectFunc  func(ctx context.Context, req core.ApprovalRequest) error
+	// Capture last received parameters for validation
+	lastSubmitRequest   *shcore.SubmitRequest
+	lastApprovalRequest *core.ApprovalRequest
+	lastRejectRequest   *core.ApprovalRequest
+}
+
+func newStubService() *stubService {
+	return &stubService{
+		handleRequestFunc: func(ctx context.Context, req shcore.SubmitRequest) error {
+			return nil
+		},
+		handleApproveFunc: func(ctx context.Context, req core.ApprovalRequest) error {
+			return nil
+		},
+		handleRejectFunc: func(ctx context.Context, req core.ApprovalRequest) error {
+			return nil
+		},
+	}
+}
+
+func (s *stubService) HandleRequest(ctx context.Context, req shcore.SubmitRequest) error {
+	// Capture request for later inspection
+	s.lastSubmitRequest = &req
+	return s.handleRequestFunc(ctx, req)
+}
+
+func (s *stubService) HandleApprove(ctx context.Context, req core.ApprovalRequest) error {
+	// Capture request for later inspection
+	s.lastApprovalRequest = &req
+	return s.handleApproveFunc(ctx, req)
+}
+
+func (s *stubService) HandleReject(ctx context.Context, req core.ApprovalRequest) error {
+	// Capture request for later inspection
+	s.lastRejectRequest = &req
+	return s.handleRejectFunc(ctx, req)
+}
+
+// CreateBadRequestError is a helper to create error similar to core.NewBadRequestError
+func createBadRequestError(message string) error {
+	return shcore.NewBadRequestError(message)
+}

--- a/internal/vacancy-worker/driver/worker/worker.go
+++ b/internal/vacancy-worker/driver/worker/worker.go
@@ -53,13 +53,13 @@ func (w *Worker) Run() error {
 		err = w.Config.Service.Handle(ctx, req)
 		if err != nil {
 			// output error and sleep for 1 second
-			log.Printf("failed to handle request (attempt %d) %s: %s, sleeping for 1 second...\n", req.Retries+1, req, err)
+			log.Printf("failed to handle request (attempt %d) %s: %s, sleeping for 1 second...\n", req.Retries+1, req.ToJSON(), err)
 			time.Sleep(1 * time.Second)
 
 			// increment retry count
 			req.Retries++
 			if req.Retries >= 3 {
-				log.Printf("discarding request after %d retries: %s\n", req.Retries, req)
+				log.Printf("discarding request after %d retries: %s\n", req.Retries, req.ToJSON())
 				return rabbitmq.NackDiscard
 			}
 


### PR DESCRIPTION
## Summary

- Added logging for the time taken to handle notifications and vacancies in `internal/notification-worker/driver/worker/worker.go` and `internal/vacancy-worker/driver/worker/worker.go`. [[1]](diffhunk://#diff-d46c18a7ec781b8c92d8b22fbce917183a1e456a6ea684432920a1508922736eR52-R62) [[2]](diffhunk://#diff-d46c18a7ec781b8c92d8b22fbce917183a1e456a6ea684432920a1508922736eR73-R76) [[3]](diffhunk://#diff-be5c3ad6792f524fa736b665e8c196a06128ef505458f7d149cf44dcbe5420b2L53-R62) [[4]](diffhunk://#diff-be5c3ad6792f524fa736b665e8c196a06128ef505458f7d149cf44dcbe5420b2R73-R76)

- Introduced a new function `prepareSubmitVacancyRequest` in `internal/server/driver/request.go` to clean up and prepare vacancy requests before handling them.
- Updated `serveSubmitVacancy` function in `internal/server/driver/rest.go` to use `prepareSubmitVacancyRequest` for request preparation.

- Modified `SaveBulkApprovalRequest` in `internal/server/driven/storage/mysql/mysql.go` to use a structured `SubmitRequest` for each message ID

- Update URL checker for crawler apply URL