### PR TITLE
Handle Large Data Encoded Token

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -216,7 +216,7 @@ A successful call indicates that the vacancy has been approved and ready to be p
 
 | Field        | Type   | Required | Description                                                           |
 | ------------ | ------ | -------- | --------------------------------------------------------------------- |
-| `data`       | String | Yes      | The value is `base64` of `JSON Web Token` consisting of vacancy data. |
+| `data`       | String | Yes      | The value is `JSON Web Token` consisting of vacancy data. |
 | `message_id` | String | No       | Message id of the email.                                              |
 
 **Example Call:**
@@ -251,7 +251,7 @@ A successful call indicates that the vacancy has been rejected and will be ignor
 
 | Field        | Type   | Required | Description                                                           |
 | ------------ | ------ | -------- | --------------------------------------------------------------------- |
-| `data`       | String | Yes      | The value is `base64` of `JSON Web Token` consisting of vacancy data. |
+| `data`       | String | Yes      | The value is `JSON Web Token` consisting of vacancy data. |
 | `message_id` | String | No       | Message id of the email.                                              |
 
 **Example Call:**

--- a/internal/server/core/service.go
+++ b/internal/server/core/service.go
@@ -161,11 +161,13 @@ func (s *service) HandleReject(ctx context.Context, approvalReq ApprovalRequest)
 func (s *service) handleBulkRequest(ctx context.Context, bulkReq core.SubmitRequest) error {
 	tokenReqs := make([]string, 0)
 	for _, v := range bulkReq.BulkVacancies {
+		// for now we only support URL submission in bulk request
 		req := core.SubmitRequest{
-			// for now we only support URL submission in bulk request
 			SubmissionType:  core.SubmitTypeURL,
 			SubmissionEmail: bulkReq.SubmissionEmail,
-			Vacancy:         v,
+			Vacancy: core.Vacancy{
+				ApplyURL: v.ApplyURL,
+			},
 		}
 
 		token, err := s.Tokenizer.EncodeRequest(req)

--- a/internal/server/core/service_test.go
+++ b/internal/server/core/service_test.go
@@ -21,10 +21,10 @@ func TestServiceHandleRequest(t *testing.T) {
 			name: "submission type bulk",
 			setupMocks: func(ctx context.Context, q *mockQueue, e *mockEmailClient, tok *mockTokenizer, a *mockApproval, s *mockApprovalStorage) {
 				tok.On("EncodeRequest", mock.MatchedBy(func(req shcore.SubmitRequest) bool {
-					return req.JobTitle == "Test 1"
+					return req.ApplyURL == "https://example.com/apply1"
 				})).Return("mock-token1", nil)
 				tok.On("EncodeRequest", mock.MatchedBy(func(req shcore.SubmitRequest) bool {
-					return req.JobTitle == "Test 2"
+					return req.ApplyURL == "https://example.com/apply2"
 				})).Return("mock-token2", nil)
 				e.On("SendBulkApprovalRequest", ctx, mock.MatchedBy(func(req shcore.SubmitRequest) bool {
 					return req.SubmissionEmail == "crawler"
@@ -40,12 +40,12 @@ func TestServiceHandleRequest(t *testing.T) {
 					{
 						JobTitle:    "Test 1",
 						CompanyName: "Test 1 Company",
-						ApplyURL:    "https://example.com/apply",
+						ApplyURL:    "https://example.com/apply1",
 					},
 					{
 						JobTitle:    "Test 2",
 						CompanyName: "Test 2 Company",
-						ApplyURL:    "https://example.com/apply",
+						ApplyURL:    "https://example.com/apply2",
 					},
 				},
 			},

--- a/internal/server/driven/token/tokenizer.go
+++ b/internal/server/driven/token/tokenizer.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"github.com/ghazlabs/idn-remote-entry/internal/shared/core"
@@ -39,8 +38,7 @@ func (t *Tokenizer) EncodeRequest(req core.SubmitRequest) (string, error) {
 		return "", fmt.Errorf("failed to sign token due to: %w", err)
 	}
 
-	encodedToken := base64.URLEncoding.EncodeToString([]byte(tokenString))
-	return encodedToken, nil
+	return tokenString, nil
 }
 
 func (t *Tokenizer) DecodeToken(tokenStr string) (core.SubmitRequest, error) {
@@ -53,12 +51,7 @@ func (t *Tokenizer) DecodeToken(tokenStr string) (core.SubmitRequest, error) {
 }
 
 func (t *Tokenizer) parseJWT(tokenStr string) (jwt.MapClaims, error) {
-	decoded, err := base64.URLEncoding.DecodeString(tokenStr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode base64 token: %w", err)
-	}
-
-	token, err := jwt.Parse(string(decoded), func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(string(tokenStr), func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}

--- a/internal/shared/core/model.go
+++ b/internal/shared/core/model.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Vacancy struct {
-	JobTitle         string   `json:"job_title" validate:"nonzero"`
-	CompanyName      string   `json:"company_name" validate:"nonzero"`
+	JobTitle         string   `json:"job_title,omitempty" validate:"nonzero"`
+	CompanyName      string   `json:"company_name,omitempty" validate:"nonzero"`
 	CompanyLocation  string   `json:"company_location,omitempty"`
 	ShortDescription string   `json:"short_description,omitempty"`
 	RelevantTags     []string `json:"relevant_tags,omitempty"`


### PR DESCRIPTION
in some cases, the server cant handle very large data encoded token. this is because we passing unnecessary data and double encoded with jwt then base64 which lead to large string 

in this PR, we remove base64 and only passing apply url vacancy in bulk 